### PR TITLE
Modify spe parameter to  comma+space

### DIFF
--- a/api/get_ip.go
+++ b/api/get_ip.go
@@ -30,7 +30,7 @@ func GetIP(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// list.  We do this because this is always the *origin* IP address, which
 	// is the *true* IP of the user.  For more information on this, see the
 	// Wikipedia page: https://en.wikipedia.org/wiki/X-Forwarded-For
-	ip := net.ParseIP(strings.Split(r.Header.Get("X-Forwarded-For"), ",")[0]).String()
+	ip := net.ParseIP(strings.Split(r.Header.Get("X-Forwarded-For"), ", ")[0]).String()
 
 	// If the user specifies a 'format' querystring, we'll try to return the
 	// user's IP address in the specified format.


### PR DESCRIPTION
As wikipedia say: 

> The general format of the field is: X-Forwarded-For: client, proxy1, proxy2[3] where the value is a **comma+space** separated list of IP addresses.