### PR TITLE
Issue-37 | Alvaro | Add cors headers

### DIFF
--- a/api/get_ip.go
+++ b/api/get_ip.go
@@ -36,6 +36,7 @@ func GetIP(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	// user's IP address in the specified format.
 	if format, ok := r.Form["format"]; ok && len(format) > 0 {
 		jsonStr, _ := json.Marshal(models.IPAddress{ip})
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 
 		switch format[0] {
 		case "json":


### PR DESCRIPTION
https://github.com/rdegges/ipify-api/issues/37
 
try to add cors header to the service so it can be query from any webpage without the workaround of jsonp